### PR TITLE
chore: align default employees with login examples

### DIFF
--- a/CoffeeShopManagementSystem/Services/EmployeeService.cs
+++ b/CoffeeShopManagementSystem/Services/EmployeeService.cs
@@ -14,8 +14,7 @@ public class EmployeeService
     {
         _employees = new Dictionary<string, Employee>
         {
-            {"B001", new Barista("B001", "Per Pettersen")},
-            {"B002", new  Barista("B002", "Kari Bremnes")},
+            {"B001", new Barista("B001", "Elsa Medel-Svensson")},
             {"S001", new Supervisor("S001", "Petrus Kowalski")},
         };
     }


### PR DESCRIPTION
Removed extra Barista (B002) from `EmployeeService` to match the login menu examples (B001 and S001).

Simplifies the default setup, removes unnecessary test data, and two test employees are more than sufficient to demonstrate the system’s functionality.

issue #60 