### PR TITLE
Add receipt option after successful payment

### DIFF
--- a/CoffeeShopManagementSystem.Tests/FakeFileService.cs
+++ b/CoffeeShopManagementSystem.Tests/FakeFileService.cs
@@ -1,0 +1,19 @@
+using CoffeeShopManagementSystem.Entities;
+using CoffeeShopManagementSystem.Interfaces;
+
+namespace CoffeeShopManagementSystem.Tests;
+
+public class FakeFileService : IFileService
+{
+    private readonly List<Order> _orders = new();
+
+    public void Save(Order order)
+    {
+        _orders.Add(order);
+    }
+
+    public List<Order> LoadOrders()
+    {
+        return _orders;
+    }
+}

--- a/CoffeeShopManagementSystem.Tests/OrderServiceTests.cs
+++ b/CoffeeShopManagementSystem.Tests/OrderServiceTests.cs
@@ -1,95 +1,69 @@
 using CoffeeShopManagementSystem.Entities;
 using CoffeeShopManagementSystem.Services;
-using CoffeeShopManagementSystem.Interfaces;
 using Xunit;
-using System.Collections.Generic;
-using System.ComponentModel;
 
-namespace CoffeeShopManagementSystem.Tests
+namespace CoffeeShopManagementSystem.Tests;
+
+public class OrderServiceTests
 {
-    //Tests for the OrderService class.
-    //OrderService handles creating and managing orders.
-    public class OrderServiceTests
+    [Fact]
+    public void CompleteOrder_WithItems_SavesCompletedOrder()
     {
-        //Test 1: Creating order with correct items,
-        [Fact]
-        public void CreateOrder_WithOrderItems_StoreItemsCorrectly()
-        {
-            // Arrange - Set up the service and an item to order.
-            var coffee1 = new Coffee{Id = 1, Name = "Espresso", Price = 45};
-            var coffee2 = new Coffee{Id = 2, Name = "Latte", Price = 50};
-            
-            var orderItem1 = new OrderItem {Coffee = coffee1, Quantity = 2};
-            var orderItem2 = new OrderItem {Coffee = coffee2, Quantity = 1};
-            
-            var items = new List<OrderItem>{orderItem1, orderItem2};
-            
-            
-            //Act - create the order.
-            var order = new Order("B001");
-            order.Items.Add(orderItem1);
-            order.Items.Add(orderItem2);
-            
-            // Assert- check that the order was created.
-            Assert.NotNull(order.Items);
-            Assert.Equal(2, order.Items.Count);
-            Assert.Equal("Espresso", order.Items[0].Coffee.Name);
-            Assert.Equal(2, order.Items[0].Quantity);
-            Assert.Equal("Latte", order.Items[1].Coffee.Name);
-            Assert.Equal(140, order.TotalPrice);
-        }
-        
-        
-        //Test 2 + Test 3: AddItem should add coffee to the order.
-        //and increase number of same coffee(test3).
-        [Fact]
-        public void AddItem_AddsNewCoffeeAndIncreaseQuantityForSameCoffee()
-        {
-            var order = new Order("B002");
-            var coffee = new Coffee{Id = 1, Name = "Cappuccino", Price = 55};
-            
-            //Act - add the coffee to the order using AddItem method.
-            order.AddItem(coffee, 2);
-            
-            // Assert - check if the items were added.
-            Assert.Single(order.Items); //Should have one item.
-            Assert.Equal("Cappuccino", order.Items[0].Coffee.Name);
-            Assert.Equal(2, order.Items[0].Quantity);
-            Assert.Equal(110, order.TotalPrice); //3*55=110
-            
-            order.AddItem(coffee, 1); //TEst 3.
-            
-            //Assert - should still have one coffee but the quantity increases.
-            Assert.Single(order.Items);
-            Assert.Equal(3,  order.Items[0].Quantity);
-            Assert.Equal(165, order.TotalPrice); //3*55=165
-        }
-        
-        
-        // Test 4: Remove item should remove coffee from order.
-        [Fact]
-        public void RemoveItem_RemovesItemFromOrder()
-        {
-            // Arrange - Create order with items
-            var order = new Order("B003");
-            var coffee1 = new Coffee{Id = 1, Name = "Mocha", Price = 60};
-            var coffee2 = new Coffee{Id = 2, Name = "Americano", Price = 40};
-            
-            order.AddItem(coffee1, 2);
-            order.AddItem(coffee2, 1);
-            
-            //Assert - order should have 2 items before removing
-            Assert.Equal(2, order.Items.Count);
-            Assert.Equal(160, order.TotalPrice); ///2*60+40=160
-            
-            //Act - remove one coffee
-            var result = order.RemoveItem(1);
-            
-            //Assert - item should be removed.
-            Assert.True(result);
-            Assert.Single(order.Items); //Should have only one item left.
-            Assert.Equal("Americano", order.Items[0].Coffee.Name); //Only Americano left in the order.
-            Assert.Equal(40, order.TotalPrice); //Only Americano price left.
-        }
+        var fakeFileService = new FakeFileService();
+        var orderService = new OrderService(fakeFileService);
+
+        var espresso = new Coffee { Id = 1, Name = "Espresso", Price = 45 };
+        var latte = new Coffee { Id = 2, Name = "Latte", Price = 50 };
+
+        orderService.StartNewOrder("B001");
+        orderService.AddToOrder(espresso, 2);
+        orderService.AddToOrder(latte, 1);
+
+        var result = orderService.CompleteOrder(new CardPaymentProcessor());
+
+        var orders = orderService.GetAllOrders();
+
+        Assert.True(result);
+        Assert.Single(orders);
+        Assert.True(orders[0].IsCompleted);
+        Assert.Equal("B001", orders[0].EmployeeId);
+        Assert.Equal(2, orders[0].Items.Count);
+        Assert.Equal(140, orders[0].TotalPrice);
+        Assert.Equal("Card", orders[0].PaymentMethod);
+    }
+
+    [Fact]
+    public void AddToOrder_WithSameCoffee_IncreasesQuantity()
+    {
+        var fakeFileService = new FakeFileService();
+        var orderService = new OrderService(fakeFileService);
+
+        var cappuccino = new Coffee { Id = 1, Name = "Cappuccino", Price = 55 };
+
+        orderService.StartNewOrder("B002");
+        orderService.AddToOrder(cappuccino, 2);
+        orderService.AddToOrder(cappuccino, 1);
+        orderService.CompleteOrder(new CardPaymentProcessor());
+
+        var order = orderService.GetAllOrders()[0];
+
+        Assert.Single(order.Items);
+        Assert.Equal(3, order.Items[0].Quantity);
+        Assert.Equal(165, order.TotalPrice);
+    }
+
+    [Fact]
+    public void CancelOrder_WithActiveOrder_DoesNotSaveOrder()
+    {
+        var fakeFileService = new FakeFileService();
+        var orderService = new OrderService(fakeFileService);
+
+        var americano = new Coffee { Id = 2, Name = "Americano", Price = 40 };
+
+        orderService.StartNewOrder("B003");
+        orderService.AddToOrder(americano, 1);
+        orderService.CancelOrder();
+
+        Assert.Empty(orderService.GetAllOrders());
     }
 }

--- a/CoffeeShopManagementSystem.Tests/OrderTests.cs
+++ b/CoffeeShopManagementSystem.Tests/OrderTests.cs
@@ -8,7 +8,7 @@ public class OrderTests
 {
     // TEST 1: New order should have correct initial  values.
     [Fact]
-    public void Order_WhenCreated_HAsCorrectInitialValues()
+    public void Order_WhenCreated_HasCorrectInitialValues()
     {
         
         //Arrange - prepare employee ID. The one creating the order.
@@ -56,7 +56,7 @@ public class OrderTests
         
         
         //Act - reduce the quantity if the item by more than the true quantity in order.
-        var result = order.ReduceItemQuantity(2, 3);
+        var result = order.ReduceItemQuantity(2, 2);
         
         // Assert - item should be completely removed.
         Assert.True(result); //Returns true if successful.

--- a/CoffeeShopManagementSystem.Tests/PaymentProcessorTests.cs
+++ b/CoffeeShopManagementSystem.Tests/PaymentProcessorTests.cs
@@ -1,6 +1,6 @@
 using CoffeeShopManagementSystem.Services;
 using Xunit;
-using System;
+
 
 namespace CoffeeShopManagementSystem.Tests;
 
@@ -11,7 +11,7 @@ public class PaymentProcessorTests
 {
     //TEST 1: Cash payment should calculate correct change.
     [Fact]
-    public void CashPaymentProcessor_WitMoreCashThanNeeded_ReturnsCorrectChange()
+    public void CashPaymentProcessor_WithMoreCashThanNeeded_ReturnsCorrectChange()
     {
         //Arrange - create cash processor and payment details.
         var processor = new CashPaymentProcessor();

--- a/CoffeeShopManagementSystem.Tests/ReportServiceTests.cs
+++ b/CoffeeShopManagementSystem.Tests/ReportServiceTests.cs
@@ -7,22 +7,6 @@ using System.Collections.Generic;
 
 namespace CoffeeShopManagementSystem.Tests
 {
-    //Fake file service for testing - stores orders in memory instead of files.
-    public class FakeFileService : IFileService
-    {
-        private List<Order> _orders = new List<Order>();
-
-        public void Save(Order order)
-        {
-            _orders.Add(order);
-        }
-
-        public List<Order> LoadOrders()
-        {
-            return _orders;
-        }
-    }
-
 
     //Tests for the ReportService class.
     //The class generates sales reports and statistics.
@@ -95,7 +79,7 @@ namespace CoffeeShopManagementSystem.Tests
 
             //Assert - should only get the completed order.
             Assert.Equal(108, result.Revenue); // Only the completed order
-            Assert.Equal(1, result.OrderCount); // Only 1 completed order}
+            Assert.Equal(1, result.OrderCount); // Only 1 completed order
         }
         
         

--- a/CoffeeShopManagementSystem/Services/MenuService.cs
+++ b/CoffeeShopManagementSystem/Services/MenuService.cs
@@ -12,7 +12,6 @@ public class MenuService
     private readonly OrderService _orderService;
     private readonly ReportService _reportService;
 
-    // Coffee menu with all available products and prices.
     private readonly List<Coffee> _coffeeMenu = new()
     {
         new Coffee(1, "Espresso",                   38m),
@@ -101,19 +100,6 @@ public class MenuService
                     break;
 
                 case 6:
-                    _orderService.CancelOrder();
-
-                    Console.Clear();
-                    Console.WriteLine("========================================");
-                    Console.WriteLine("Order Canceled");
-                    Console.WriteLine("========================================");
-                    Console.WriteLine();
-                    Console.WriteLine("The current order has been canceled.");
-                    Thread.Sleep(2000);
-
-                    inOrderMenu = false;
-                    break;
-
                 case 0:
                     _orderService.CancelOrder();
 
@@ -274,24 +260,8 @@ public class MenuService
                 break;
 
             case '-':
-            {
-                int currentQuantity = selectedItem.Quantity;
-
                 success = _orderService.ReduceFromOrder(selectedItem.Coffee.Id, amount);
-
-                if (!success)
-                {
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.Write("Error");
-                    Console.ResetColor();
-                    Console.WriteLine($" - You only have {currentQuantity} item(s).");
-                    Console.WriteLine("Press any key to continue...");
-                    Console.ReadKey();
-                    return;
-                }
-
                 break;
-            }
 
             default:
                 Console.ForegroundColor = ConsoleColor.Red;
@@ -303,10 +273,21 @@ public class MenuService
                 return;
         }
 
-        Console.ForegroundColor = ConsoleColor.Green;
-        Console.Write("Success");
-        Console.ResetColor();
-        Console.WriteLine(" - Quantity updated.");
+        if (success)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.Write("Success");
+            Console.ResetColor();
+            Console.WriteLine(" - Quantity updated.");
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write("Error");
+            Console.ResetColor();
+            Console.WriteLine(" - Item could not be updated.");
+        }
+
         Console.WriteLine("Press any key to continue...");
         Console.ReadKey();
     }
@@ -418,9 +399,11 @@ public class MenuService
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.Write("Success");
                     Console.ResetColor();
-                    Console.WriteLine(" - Payment via Cash accepted.");
+                    Console.WriteLine(" - Payment accepted and order saved.");
                     Console.WriteLine($"Change to customer: {change} kr");
-                    Console.WriteLine("Order saved.");
+                    Console.WriteLine();
+
+                    AskPrintReceipt(order);
                 }
                 else
                 {
@@ -445,8 +428,8 @@ public class MenuService
                     Thread.Sleep(300);
                     Console.Write(".");
                 }
-
                 Console.WriteLine();
+
                 Thread.Sleep(300);
 
                 Console.Write("Waiting for PIN");
@@ -455,11 +438,11 @@ public class MenuService
                     Thread.Sleep(300);
                     Console.Write(".");
                 }
-
                 Console.WriteLine();
-                Thread.Sleep(300);
 
+                Thread.Sleep(300);
                 Console.WriteLine("PIN entered..");
+
                 Thread.Sleep(300);
 
                 Console.Write("Connecting to card provider");
@@ -468,22 +451,34 @@ public class MenuService
                     Thread.Sleep(300);
                     Console.Write(".");
                 }
-
                 Console.WriteLine();
+
                 Thread.Sleep(300);
 
                 IPaymentProcessor processor = new CardPaymentProcessor();
-                _orderService.CompleteOrder(processor);
+                bool success = _orderService.CompleteOrder(processor);
 
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.Write("Success");
-                Console.ResetColor();
-                Console.WriteLine(" - Payment with card accepted.");
-                Console.WriteLine("Order saved.");
+                if (success)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.Write("Success");
+                    Console.ResetColor();
+                    Console.WriteLine(" - Payment accepted and order saved.");
+                    Console.WriteLine();
+
+                    AskPrintReceipt(order);
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Write("Error");
+                    Console.ResetColor();
+                    Console.WriteLine(" - Card payment failed.");
+                }
 
                 Console.WriteLine("Press any key to continue...");
                 Console.ReadKey();
-                return true;
+                return success;
             }
 
             case 3:
@@ -496,29 +491,77 @@ public class MenuService
                     Thread.Sleep(300);
                     Console.Write(".");
                 }
-
                 Console.WriteLine();
 
                 Thread.Sleep(300);
                 Console.WriteLine("Payment registered.");
 
                 IPaymentProcessor processor = new VippsPaymentProcessor();
-                _orderService.CompleteOrder(processor);
+                bool success = _orderService.CompleteOrder(processor);
 
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.Write("Success");
-                Console.ResetColor();
-                Console.WriteLine(" - Payment via Vipps accepted.");
-                Console.WriteLine("Order saved.");
+                if (success)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.Write("Success");
+                    Console.ResetColor();
+                    Console.WriteLine(" - Payment accepted and order saved.");
+                    Console.WriteLine();
+
+                    AskPrintReceipt(order);
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Write("Error");
+                    Console.ResetColor();
+                    Console.WriteLine(" - Vipps payment failed.");
+                }
 
                 Console.WriteLine("Press any key to continue...");
                 Console.ReadKey();
-                return true;
+                return success;
             }
 
             default:
                 return false;
         }
+    }
+
+    private void AskPrintReceipt(Order order)
+    {
+        Console.Write("Print receipt? (y/n): ");
+        string choice = Console.ReadLine() ?? "";
+
+        if (choice.ToLower() != "y")
+        {
+            return;
+        }
+
+        Console.Clear();
+
+        Console.WriteLine("========================================");
+        Console.WriteLine("Receipt");
+        Console.WriteLine("========================================");
+        Console.WriteLine();
+
+        Console.WriteLine($"Order ID: {order.OrderId}");
+        Console.WriteLine($"Employee ID: {order.EmployeeId}");
+        Console.WriteLine($"Date: {order.Timestamp:dd.MM.yyyy} - Time: {order.Timestamp:HH:mm}");
+        Console.WriteLine($"Payment method: {order.PaymentMethod}");
+        Console.WriteLine();
+
+        Console.WriteLine("Items:");
+        Console.WriteLine("----------------------------------------");
+
+        foreach (OrderItem item in order.Items)
+        {
+            Console.WriteLine($"{item.Quantity} x {item.Coffee.Name} - {item.Subtotal} kr");
+        }
+
+        Console.WriteLine("----------------------------------------");
+        Console.WriteLine($"Total: {order.TotalPrice} kr");
+        Console.WriteLine("========================================");
+        Console.WriteLine();
     }
 
     public void ShowOrderHistoryMenu(Employee employee)


### PR DESCRIPTION
Users are now asked if they want a receipt only after the transaction is completed, resulting in a cleaner and more natural workflow.