### PR TITLE
refactor: remove unused using statements

### DIFF
--- a/CoffeeShopManagementSystem.Tests/OrderServiceTests.cs
+++ b/CoffeeShopManagementSystem.Tests/OrderServiceTests.cs
@@ -1,6 +1,6 @@
 using CoffeeShopManagementSystem.Entities;
 using CoffeeShopManagementSystem.Services;
-using Xunit;
+
 
 namespace CoffeeShopManagementSystem.Tests;
 

--- a/CoffeeShopManagementSystem.Tests/OrderTests.cs
+++ b/CoffeeShopManagementSystem.Tests/OrderTests.cs
@@ -1,6 +1,5 @@
 using CoffeeShopManagementSystem.Entities;
-using Xunit;
-using System;
+
 
 namespace CoffeeShopManagementSystem.Tests;
 

--- a/CoffeeShopManagementSystem.Tests/PaymentProcessorTests.cs
+++ b/CoffeeShopManagementSystem.Tests/PaymentProcessorTests.cs
@@ -1,5 +1,5 @@
 using CoffeeShopManagementSystem.Services;
-using Xunit;
+
 
 
 namespace CoffeeShopManagementSystem.Tests;

--- a/CoffeeShopManagementSystem.Tests/ReportServiceTests.cs
+++ b/CoffeeShopManagementSystem.Tests/ReportServiceTests.cs
@@ -1,9 +1,6 @@
 using CoffeeShopManagementSystem.Services;
 using CoffeeShopManagementSystem.Entities;
-using CoffeeShopManagementSystem.Interfaces;
-using Xunit;
-using System;
-using System.Collections.Generic;
+
 
 namespace CoffeeShopManagementSystem.Tests
 {

--- a/CoffeeShopManagementSystem/Services/MenuService.cs
+++ b/CoffeeShopManagementSystem/Services/MenuService.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using CoffeeShopManagementSystem.Entities;
 using CoffeeShopManagementSystem.Interfaces;
 using CoffeeShopManagementSystem.Utils;


### PR DESCRIPTION
Removed unnecessary using directives in multiple files
Cleaned up outdated references


* As the system has developed, some code has been refactored or removed, leaving behind unused using statements.

